### PR TITLE
Various fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import argparse
 import logging
 from asyncio import get_event_loop, ensure_future
-import os
+from pathlib import Path
 
 from tribler_apptester.executor import Executor
 
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     parser.add_argument('--monitordownloads', default=None, type=int, help='monitor the downloads with a specified interval in seconds')
     parser.add_argument('--monitorresources', default=None, type=int, help='monitor the resources with a specified interval in seconds')
     parser.add_argument('--monitoripv8', default=None, type=int, help='monitor IPv8 overlays with a specified interval in seconds')
-    parser.add_argument('--magnetsfile', default=os.path.join('data', 'torrent_links.txt'), type=str, help='specify the location of the file with magnet links')
+    parser.add_argument('--magnetsfile', default=Path("tribler_apptester") / "data" / "torrent_links.txt", type=str, help='specify the location of the file with magnet links')
 
     # Setup logging
     logging.basicConfig(level=logging.DEBUG)

--- a/tribler_apptester/actions/page_action.py
+++ b/tribler_apptester/actions/page_action.py
@@ -10,7 +10,6 @@ class PageAction(ClickSequenceAction):
     This action goes to a specific page in Tribler.
     """
     BUTTONS_TO_PAGES = {
-        'home': ['window.left_menu_button_home'],
         'discovered': ['window.left_menu_button_discovered'],
         'downloads': ['window.left_menu_button_downloads'],
         'my_channel': ['window.left_menu_button_my_channel'],

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -145,7 +145,7 @@ class Executor(object):
         self.determine_probabilities()
 
         if not self.args.silent:
-            self.random_action_lc = ensure_future(looping_call(0, 5, self.perform_random_action))
+            self.random_action_lc = ensure_future(looping_call(0, 15, self.perform_random_action))
 
         if self.args.monitordownloads:
             self.download_monitor = DownloadMonitor(self.request_manager, self.args.monitordownloads)

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -255,7 +255,8 @@ class Executor(object):
         Tribler has crashed. Handle the error and shut everything down.
         """
         self._logger.error("********** TRIBLER CRASHED **********")
-        self._logger.error("Tribler crashed after uptime of %s sec! Stack trace: %s", self.uptime, traceback)
+        self._logger.error("Tribler crashed after uptime of %s sec! Stack trace: %s",
+                           self.uptime, traceback.decode('utf-8'))
         self.tribler_crashed = True
         ensure_future(self.stop(1))
 

--- a/tribler_apptester/utils/asyncio.py
+++ b/tribler_apptester/utils/asyncio.py
@@ -1,10 +1,18 @@
-from asyncio import sleep
+from asyncio import Future, iscoroutine, sleep
+
+
+def maybe_coroutine(func, *args, **kwargs):
+    value = func(*args, **kwargs)
+    if iscoroutine(value) or isinstance(value, Future):
+        return value
+
+    async def coro():
+        return value
+    return coro()
 
 
 async def looping_call(delay, interval, task, *args):
     await sleep(delay)
     while True:
-        res = task(*args)
-        if res:
-            await task(*args)
+        await maybe_coroutine(task, *args)
         await sleep(interval)

--- a/tribler_apptester/utils/asyncio.py
+++ b/tribler_apptester/utils/asyncio.py
@@ -1,8 +1,10 @@
-from asyncio import sleep, ensure_future
+from asyncio import sleep
 
 
 async def looping_call(delay, interval, task, *args):
     await sleep(delay)
     while True:
-        ensure_future(task(*args))
+        res = task(*args)
+        if res:
+            await task(*args)
         await sleep(interval)


### PR DESCRIPTION
- Fixed an error where the path to the torrents could not be found.
- Fixed an error where an await would accept a `None` value and crash.
- Increased the random action interval to 15 seconds.
- Removed the home button action.
- Decoding the stack trace before printing it, after Tribler has crashed.
- Using `maybe_coroutine` to ensure that we `await` the expected object.