### PR TITLE
Various fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tmp_scripts/**
 output/**
 screenshots/**
+**.DS_Store

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--plain', action='store_true', help='allow plain downloads')
     parser.add_argument('-d', '--duration', default=None, type=int, help='run the Tribler application tester for a specific period of time')
     parser.add_argument('-s', '--silent', action='store_true', help='do not execute random actions')
+    parser.add_argument('-t', '--testnet', action='store_true', help='start Tribler with the testnet flag')
     parser.add_argument('--codeport', default=5500, type=int, help='the port used to execute code')
     parser.add_argument('--monitordownloads', default=None, type=int, help='monitor the downloads with a specified interval in seconds')
     parser.add_argument('--monitorresources', default=None, type=int, help='monitor the resources with a specified interval in seconds')

--- a/scripts/downloads.r
+++ b/scripts/downloads.r
@@ -35,4 +35,14 @@ if(file.exists("output/download_stats.csv")){
     p
 
     ggsave(file="output/progress.png", width=8, height=6, dpi=100)
+
+    # State
+    df2 <- aggregate(df, by=list(df$time, df$status), FUN="length")
+    p <- ggplot(df2, aes(x=Group.1, y=status, group=Group.2, colour=Group.2)) + theme_bw()
+    p <- p + geom_line()
+    p <- p + theme(legend.position="bottom", legend.direction="horizontal") + xlab("Time into experiment (sec)") + ylab("Count") + ggtitle("Status of individual downloads")
+    p <- p + guides(colour=guide_legend(ncol=3))
+    p
+
+    ggsave(file="output/download_states.png", width=8, height=6, dpi=100)
 }

--- a/scripts/requests.r
+++ b/scripts/requests.r
@@ -1,0 +1,28 @@
+is.installed <- function(mypkg) is.element(mypkg, installed.packages()[,1])
+if (is.installed("ggplot2") == FALSE){
+    install.packages("ggplot2", repos = "http://cran.r-project.org")
+}
+
+library(ggplot2)
+
+if(file.exists("output/request_times.csv")){
+	df <- read.csv("output/request_times.csv", sep=",", header=T)
+    df$start_time <- df$start_time / 1000.0
+
+    # Boxplot
+    p <- ggplot(df, aes(x=request_type, y=duration, fill=request_type)) + theme_bw()
+    p <- p + geom_boxplot()
+    p <- p + theme(legend.position="bottom", legend.direction="horizontal") + xlab("Request endpoint") + ylab("Request duration (ms)") + ggtitle("Duration of various requests")
+    p <- p + coord_flip()
+    p
+
+    ggsave(file="output/request_times_boxplot.png", width=8, height=6, dpi=100)
+
+    # Plotting the durations over time
+    p <- ggplot(df, aes(x=start_time, y=duration, group=request_type, colour=request_type)) + theme_bw()
+    p <- p + geom_line()
+    p <- p + theme(legend.position="bottom", legend.direction="horizontal") + xlab("Time since start (s.)") + ylab("Request duration (ms)") + ggtitle("Duration of various requests")
+    p
+
+    ggsave(file="output/request_times.png", width=8, height=6, dpi=100)
+}

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -109,6 +109,7 @@ class Executor(object):
             started = await self.request_manager.is_tribler_started()
             if started:
                 success = True
+                self.request_manager.tribler_start_time = int(round(time.time() * 1000))
                 break
             else:
                 await sleep(5)

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -90,7 +90,11 @@ class Executor(object):
         Start Tribler if it has not been started yet.
         """
         self._logger.info("Tribler not running - starting it")
-        self.tribler_process = subprocess.Popen("%s --allow-code-injection --testnet" % self.tribler_path, shell=True)
+        cmd = "%s --allow-code-injection" % self.tribler_path
+        if self.args.testnet:
+            cmd += " --testnet"
+
+        self.tribler_process = subprocess.Popen(cmd, shell=True)
         await sleep(5)
 
         loaded_config = await self.load_tribler_config()

--- a/tribler_apptester/monitors/download_monitor.py
+++ b/tribler_apptester/monitors/download_monitor.py
@@ -63,8 +63,8 @@ class DownloadMonitor(object):
         """
         downloads = await self.request_manager.get_downloads()
         for download in downloads["downloads"]:
+            time_diff = time.time() - self.start_time
             with open(self.download_stats_file_path, "a") as output_file:
-                time_diff = time.time() - self.start_time
                 output_file.write("%s,%s,%s,%s,%s,%f\n" % (time_diff,
                                                            download["infohash"],
                                                            download["status"],

--- a/tribler_apptester/requestmgr.py
+++ b/tribler_apptester/requestmgr.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import
-
 import logging
+import os
+import time
 
 import aiohttp
 
@@ -13,58 +13,65 @@ class HTTPRequestManager(object):
     def __init__(self, api_key):
         self._logger = logging.getLogger(self.__class__.__name__)
         self.headers = {'User-Agent': 'Tribler application tester', 'X-Api-Key': api_key}
+        self.tribler_start_time = None
 
-    async def get_token_balance(self):
+        # Create the output directory if it does not exist yet
+        output_dir = os.path.join(os.getcwd(), "output")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        self.request_times_file_path = os.path.join(output_dir, 'request_times.csv')
+
+        with open(self.request_times_file_path, "w") as output_file:
+            output_file.write("request_type,start_time,duration\n")
+
+    def write_request_time(self, request_type, start_time):
+        current_time = int(round(time.time() * 1000))
+        request_time = current_time - start_time
+        time_since_start = current_time - self.tribler_start_time
+        with open(self.request_times_file_path, "a") as output_file:
+            output_file.write("%s,%d,%d\n" % (request_type, time_since_start, request_time))
+
+    async def get_json_from_endpoint(self, endpoint):
         """
-        Perform a request to the core to get the token balance.
+        Perform a JSON request and log the request type and duration.
         """
         async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/wallets", headers=self.headers)
-            json_response = response.json()
-
-            if "MB" not in json_response["wallets"]:
-                return 0
-            return json_response["wallets"]["MB"]["balance"]["available"]
+            start_time = int(round(time.time() * 1000))
+            response = await client.get("http://localhost:8085/%s" % endpoint, headers=self.headers)
+            json_response = await response.json()
+            self.write_request_time(endpoint, start_time)
+            return json_response
 
     async def get_downloads(self):
         """
         Perform a request to the core to get the downloads
         """
-        async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/downloads", headers=self.headers)
-            return await response.json()
+        return await self.get_json_from_endpoint("downloads")
 
     async def get_circuits_info(self):
         """
         Perform a request to the core to get circuits information
         """
-        async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/ipv8/tunnel/circuits", headers=self.headers)
-            return await response.json()
+        return await self.get_json_from_endpoint("ipv8/tunnel/circuits")
 
     async def get_overlay_statistics(self):
         """
         Perform a request to the core to get IPv8 overlay statistics
         """
-        async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/ipv8/overlays", headers=self.headers)
-            return await response.json()
+        return await self.get_json_from_endpoint("ipv8/overlays")
 
     async def get_memory_history_core(self):
         """
         Perform a request to the core to get the memory usage history
         """
-        async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/debug/memory/history", headers=self.headers)
-            return await response.json()
+        return await self.get_json_from_endpoint("debug/memory/history")
 
     async def get_cpu_history_core(self):
         """
         Perform a request to the core to get the CPU usage history
         """
-        async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/debug/cpu/history", headers=self.headers)
-            return await response.json()
+        return await self.get_json_from_endpoint("debug/cpu/history")
 
     async def get_state(self):
         """

--- a/tribler_apptester/utils/osutils.py
+++ b/tribler_apptester/utils/osutils.py
@@ -29,4 +29,4 @@ else:
         return Path().home()
 
     def get_appstate_dir():
-        return get_home_dir()
+        return get_home_dir() / ".Tribler"


### PR DESCRIPTION
- Refactored the request manager so it logs the request duration. This should hopefully help to reveal core freezes (see issue https://github.com/Tribler/tribler/issues/5296)
- Plotting the request times after the experiment, both in a boxplot and line chart.
- The application tester now uses the mainnet. The testnet can still be toggled by passing the `--testnet` parameter.
- Improved state dir selection mechanism when loading the configuration files.
- Plotting the download states after the experiment.