### PR TITLE
Removed absolute_import imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import argparse
 import logging
 from asyncio import get_event_loop, ensure_future

--- a/tribler_apptester/action.py
+++ b/tribler_apptester/action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from abc import abstractmethod
 
 

--- a/tribler_apptester/action_sequence.py
+++ b/tribler_apptester/action_sequence.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-
 class ActionSequence(object):
     """
     An action sequence is a list of actions. This allows programmers to define their own complicated sequence.

--- a/tribler_apptester/actions/change_anonymity_action.py
+++ b/tribler_apptester/actions/change_anonymity_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/change_download_files_action.py
+++ b/tribler_apptester/actions/change_download_files_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/click_action.py
+++ b/tribler_apptester/actions/click_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/custom_action.py
+++ b/tribler_apptester/actions/custom_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/explore_channel_action.py
+++ b/tribler_apptester/actions/explore_channel_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction, RandomTableViewClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/explore_download_action.py
+++ b/tribler_apptester/actions/explore_download_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/key_action.py
+++ b/tribler_apptester/actions/key_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/keys_action.py
+++ b/tribler_apptester/actions/keys_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/page_action.py
+++ b/tribler_apptester/actions/page_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from random import choice
 
 from tribler_apptester.actions.click_action import ClickSequenceAction

--- a/tribler_apptester/actions/remove_download_action.py
+++ b/tribler_apptester/actions/remove_download_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/screenshot_action.py
+++ b/tribler_apptester/actions/screenshot_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 
 from tribler_apptester.action import Action

--- a/tribler_apptester/actions/scroll_action.py
+++ b/tribler_apptester/actions/scroll_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/scroll_discovered_action.py
+++ b/tribler_apptester/actions/scroll_discovered_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.page_action import PageAction
 from tribler_apptester.actions.scroll_action import RandomScrollAction

--- a/tribler_apptester/actions/search_action.py
+++ b/tribler_apptester/actions/search_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from random import choice
 
 from tribler_apptester.action_sequence import ActionSequence

--- a/tribler_apptester/actions/select_action.py
+++ b/tribler_apptester/actions/select_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/shutdown_action.py
+++ b/tribler_apptester/actions/shutdown_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/actions/start_download_action.py
+++ b/tribler_apptester/actions/start_download_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from random import choice
 
 from tribler_apptester.action_sequence import ActionSequence

--- a/tribler_apptester/actions/start_vod_action.py
+++ b/tribler_apptester/actions/start_vod_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction
 from tribler_apptester.actions.custom_action import CustomAction

--- a/tribler_apptester/actions/subscribe_unsubscribe_action.py
+++ b/tribler_apptester/actions/subscribe_unsubscribe_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action_sequence import ActionSequence
 from tribler_apptester.actions.click_action import ClickAction, RandomTableViewClickAction
 from tribler_apptester.actions.conditional_action import ConditionalAction

--- a/tribler_apptester/actions/wait_action.py
+++ b/tribler_apptester/actions/wait_action.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from tribler_apptester.action import Action
 
 

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 import logging
 import os

--- a/tribler_apptester/monitors/download_monitor.py
+++ b/tribler_apptester/monitors/download_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 import time

--- a/tribler_apptester/monitors/ipv8_monitor.py
+++ b/tribler_apptester/monitors/ipv8_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 import time

--- a/tribler_apptester/monitors/resource_monitor.py
+++ b/tribler_apptester/monitors/resource_monitor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 import time

--- a/tribler_apptester/tcpsocket.py
+++ b/tribler_apptester/tcpsocket.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 from asyncio import open_connection, get_event_loop, ensure_future
 from base64 import b64decode


### PR DESCRIPTION
We don't maintain compatibility with Python 2 so these statements can be removed.