### PR TITLE
Add sentry error reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,17 @@
 import argparse
 import logging
-from asyncio import get_event_loop, ensure_future
+import os
+from asyncio import ensure_future, get_event_loop
 from pathlib import Path
+
+import sentry_sdk
 
 from tribler_apptester.executor import Executor
 
+sentry_sdk.init(
+    os.environ.get('SENTRY_URL', 'https://e489691c2e214c03961e18069a71d76c@sentry.tribler.org/6'),
+    traces_sample_rate=1.0
+)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Run a Tribler application test.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
 configobj
+sentry-sdk


### PR DESCRIPTION
This PR adds sentry error reporting.

Issues will be collected in this project: https://sentry.tribler.org/tribler/application-tester

### How to change Sentry URL

```bash
export SENTRY_URL=<sentry_url>
```