### PR TITLE
Remove dead page actions

### DIFF
--- a/tribler_apptester/actions/page_action.py
+++ b/tribler_apptester/actions/page_action.py
@@ -11,12 +11,12 @@ class PageAction(ClickSequenceAction):
         'discovered': ['window.left_menu_button_discovered'],
         'downloads': ['window.left_menu_button_downloads'],
         'my_channel': ['window.left_menu_button_my_channel'],
-        'search': ['window.left_menu_button_search'],
+        'search': [],
         'subscriptions': ['window.left_menu_button_subscriptions'],
         'video_player': ['window.left_menu_button_video_player'],
         'token_balance': ['window.token_balance_widget'],
         'settings': ['window.settings_button'],
-        'market': ['window.token_balance_widget', 'window.trade_button'],
+        'market': [],
         'trust_graph': ['window.left_menu_button_trust_graph']
     }
 


### PR DESCRIPTION
Remove the page actions that are no longer available or visible for 7.7 release.
1. Search page
- Left sidebar search menu button is not available anymore
2. Market page
- No entry to market page is available and no trade button