### PR TITLE
Remove left menu my channel action

### DIFF
--- a/tribler_apptester/actions/page_action.py
+++ b/tribler_apptester/actions/page_action.py
@@ -10,7 +10,6 @@ class PageAction(ClickSequenceAction):
     BUTTONS_TO_PAGES = {
         'discovered': ['window.left_menu_button_discovered'],
         'downloads': ['window.left_menu_button_downloads'],
-        'my_channel': ['window.left_menu_button_my_channel'],
         'search': [],
         'token_balance': ['window.token_balance_widget'],
         'settings': ['window.settings_button'],


### PR DESCRIPTION
Left sidebar my channel button is not available anymore. It should be updated to include the sidebar subscribed channel (separate PR later)