### PR TITLE
Set API port as commandline argument to executor

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
     parser.add_argument('-d', '--duration', default=None, type=int, help='run the Tribler application tester for a specific period of time')
     parser.add_argument('-s', '--silent', action='store_true', help='do not execute random actions')
     parser.add_argument('--codeport', default=5500, type=int, help='the port used to execute code')
+    parser.add_argument('--apiport', default=52194, type=int, help='the port used by Tribler REST API')
     parser.add_argument('--monitordownloads', default=None, type=int, help='monitor the downloads with a specified interval in seconds')
     parser.add_argument('--monitorresources', default=None, type=int, help='monitor the resources with a specified interval in seconds')
     parser.add_argument('--monitoripv8', default=None, type=int, help='monitor IPv8 overlays with a specified interval in seconds')

--- a/tribler_apptester/executor.py
+++ b/tribler_apptester/executor.py
@@ -45,6 +45,7 @@ class Executor(object):
         self.args = args
         self.tribler_path = args.tribler_executable
         self.code_port = args.codeport
+        self.api_port = args.apiport
         self._logger = logging.getLogger(self.__class__.__name__)
         self.allow_plain_downloads = args.plain
         self.magnets_file_path = args.magnetsfile
@@ -99,7 +100,7 @@ class Executor(object):
             self._logger.warning("Loading Tribler config loaded, aborting")
             ensure_future(self.stop(1))
         else:
-            self.request_manager = HTTPRequestManager(self.tribler_config['api']['key'])
+            self.request_manager = HTTPRequestManager(self.tribler_config['api']['key'], self.api_port)
             await self.check_tribler_started()
 
     async def check_tribler_started(self):

--- a/tribler_apptester/requestmgr.py
+++ b/tribler_apptester/requestmgr.py
@@ -10,9 +10,10 @@ class HTTPRequestManager(object):
     This class manages requests to the Tribler core.
     """
 
-    def __init__(self, api_key):
+    def __init__(self, api_key, api_port):
         self._logger = logging.getLogger(self.__class__.__name__)
         self.headers = {'User-Agent': 'Tribler application tester', 'X-Api-Key': api_key}
+        self.api_port = api_port
         self.tribler_start_time = None
 
         # Create the output directory if it does not exist yet
@@ -38,7 +39,7 @@ class HTTPRequestManager(object):
         """
         async with aiohttp.ClientSession() as client:
             start_time = int(round(time.time() * 1000))
-            response = await client.get("http://localhost:8085/%s" % endpoint, headers=self.headers)
+            response = await client.get(f"http://localhost:{self.api_port}/{endpoint}", headers=self.headers)
             json_response = await response.json()
             self.write_request_time(endpoint, start_time)
             return json_response
@@ -78,7 +79,7 @@ class HTTPRequestManager(object):
         Get the current state of the Tribler instance
         """
         async with aiohttp.ClientSession() as client:
-            response = await client.get("http://localhost:8085/state", headers=self.headers)
+            response = await client.get(f"http://localhost:{self.api_port}/state", headers=self.headers)
             return await response.json()
 
     async def is_tribler_started(self):


### PR DESCRIPTION
With the recent default API port update of Tribler, the application tester is unable to check start and stop state of Tribler. This PR sets API port as command line argument to the executor similar to code port so that the port can be specified externally.

With this, Jenkins job can be updated to make it work with both the old and new Tribler versions.